### PR TITLE
add categoryType field with validation

### DIFF
--- a/src/app/modules/auth/auth.controller.ts
+++ b/src/app/modules/auth/auth.controller.ts
@@ -6,12 +6,13 @@ import { Request, Response } from 'express';
 import config from '../../config';
 
 const registerStudent = catchAsync(async (req: Request, res: Response) => {
-    const { otpCode, name, email, phone, password } = req.body;
+    const { otpCode, name, email, categoryType, phone, password } = req.body;
 
     const result = await authService.registerStudent(
         otpCode,
         name,
         email,
+        categoryType,
         phone,
         password,
     );

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -14,12 +14,14 @@ import { formatPhoneNumber } from '../../utils/formatPhoneNumber';
 import { PhoneVerification } from '../phoneVerification/phoneVerification.model';
 import { PHONE_VERIFICATION_TYPE } from '../phoneVerification/phoneVerification.constant';
 import { convertJWTExpireTimeToSeconds } from './auth.utils';
+import { CategoryType } from '../category/category.constant';
 
 // Register Student
 const registerStudent = async (
     otpCode: string,
     name: string,
     email: string,
+    categoryType: CategoryType,
     phone: string,
     password: string,
 ) => {
@@ -74,6 +76,7 @@ const registerStudent = async (
             name: name,
             email: newUser[0].email,
             phone: newUser[0].phone,
+            categoryType,
         };
 
         const newStudent = await Student.create([student], { session });

--- a/src/app/modules/auth/auth.validation.ts
+++ b/src/app/modules/auth/auth.validation.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { categoryType } from '../category/category.constant';
 
 const registerStudentValidationSchema = z.object({
     body: z
@@ -17,6 +18,10 @@ const registerStudentValidationSchema = z.object({
                 .trim()
                 .min(2, 'Student name must be at least 2 characters')
                 .max(20, 'Student name cannot be more than 20 characters'),
+            categoryType: z.enum([...(categoryType as [string, ...string[]])], {
+                required_error: 'Category type is required',
+                invalid_type_error: `Invalid categoryType. Allowed values are: ${Object.values(categoryType).join(', ')}`,
+            }),
             email: z
                 .string({
                     required_error: 'Email is required',

--- a/src/app/modules/student/student.interface.ts
+++ b/src/app/modules/student/student.interface.ts
@@ -1,9 +1,11 @@
 import { Types } from 'mongoose';
+import { CategoryType } from '../category/category.constant';
 
 export interface IStudent {
     user_id: Types.ObjectId;
     studentId: string;
     name: string;
+    categoryType: CategoryType;
     phone: string;
     email: string;
     profileImageURL: string;

--- a/src/app/modules/student/student.model.ts
+++ b/src/app/modules/student/student.model.ts
@@ -1,6 +1,7 @@
 import { Schema, model } from 'mongoose';
 import { IStudent } from './student.interface';
 import { formatPhoneNumber } from '../../utils/formatPhoneNumber';
+import { categoryType } from '../category/category.constant';
 
 // Student Schema
 const studentSchema = new Schema<IStudent>(
@@ -19,6 +20,15 @@ const studentSchema = new Schema<IStudent>(
             type: String,
             trim: true,
             maxlength: [20, 'Student name cannot be more than 20 characters'],
+        },
+        categoryType: {
+            type: String,
+            enum: {
+                values: categoryType,
+                message:
+                    '{VALUE} is not a valid category type. Category type must be either Academic, Admission, or Job',
+            },
+            required: [true, 'Category type is required'],
         },
         phone: {
             type: String,

--- a/src/app/modules/user/user.model.ts
+++ b/src/app/modules/user/user.model.ts
@@ -49,14 +49,15 @@ const userSchema = new Schema<IUser, IUserModel>(
             type: String,
             unique: true,
             required: true,
-            validate: [
-                {
-                    validator: function (email: string) {
-                        return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-                    },
-                    message: 'Invalid email format',
+            validate: {
+                validator: function (v: string) {
+                    return /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(
+                        v,
+                    );
                 },
-            ],
+                message: (props) =>
+                    `${props.value} is not a valid email address!`,
+            },
         },
         passwordChangedAt: { type: Date },
         isDeleted: { type: Boolean, default: false },


### PR DESCRIPTION
- Add categoryType enum ('Academic', 'Admission', 'Job') to Student schema
- Implement mongoose enum validation with error messages 
- Add Zod validation for categoryType in registration schema
- Update Student interface to include new required field

BREAKING CHANGE: Student schema now requires categoryType field for new records